### PR TITLE
Material Web rebuild for GitHub Pages deployment

### DIFF
--- a/about.html
+++ b/about.html
@@ -22,9 +22,13 @@
 
     <link href="./media/style.css" rel="stylesheet">
 
+    <link href="./media/material-theme.css" rel="stylesheet">
+
     <title>Creasoft - Software and Digital Agency HTML Template</title>
+    <script type="module" src="https://unpkg.com/@material/web/all.js?module"></script>
+
 </head>
-<body>
+<body class="material-theme">
 
 <div class="preloader" style="display: none;">
     <div class="loader">
@@ -250,12 +254,12 @@
                         <ul class="footer-menu">
                             <li><a class="active" href="about.html">About Us</a></li>
                             <li>
-                                <a href="services.html">Services</a>
+                                <a href="service.html">Services</a>
                             </li>
                             <li><a href="project.html">Project</a></li>
                             <li><a href="blog.html">Blog</a></li>
                             <li><a href="contact.html">Career</a></li>
-                            <li><a href="services.html">Pricing
+                            <li><a href="service.html">Pricing
                                 Plan</a></li>
                         </ul>
                     </div>
@@ -277,8 +281,8 @@
                                 <i class="far fa-envelope"></i>
                             </div>
                             <div class="email">
-                                <a href="tell:info@example.com">info@example.com</a>
-                                <a href="tell:info@support.com">info@support.com</a>
+                                <a href="tel:info@example.com">info@example.com</a>
+                                <a href="tel:info@support.com">info@support.com</a>
                             </div>
                         </div>
                         <div class="address">
@@ -329,6 +333,8 @@
 <script src="media/jquery.magnific-popup.min.js"></script>
 
 <script src="media/wow.min.js"></script>
+
+<script src="./media/material-init.js"></script>
 
 <script src="./media/custom.js"></script>
 

--- a/blog-details.html
+++ b/blog-details.html
@@ -23,9 +23,13 @@
 
     <link href="./media/style.css" rel="stylesheet">
 
+    <link href="./media/material-theme.css" rel="stylesheet">
+
     <title>Creasoft - Software and Digital Agency HTML Template</title>
+    <script type="module" src="https://unpkg.com/@material/web/all.js?module"></script>
+
 </head>
-<body>
+<body class="material-theme">
 
 <div class="preloader" style="display: none;">
     <div class="loader">
@@ -452,12 +456,12 @@
                         <ul class="footer-menu">
                             <li><a href="about.html">About Us</a></li>
                             <li>
-                                <a href="services.html">Services</a>
+                                <a href="service.html">Services</a>
                             </li>
                             <li><a href="project.html">Project</a></li>
                             <li><a href="blog.html">Blog</a></li>
                             <li><a href="contact.html">Career</a></li>
-                            <li><a href="services.html">Pricing
+                            <li><a href="service.html">Pricing
                                 Plan</a></li>
                         </ul>
                     </div>
@@ -479,8 +483,8 @@
                                 <i class="far fa-envelope"></i>
                             </div>
                             <div class="email">
-                                <a href="tell:info@example.com">info@example.com</a>
-                                <a href="tell:info@support.com">info@support.com</a>
+                                <a href="tel:info@example.com">info@example.com</a>
+                                <a href="tel:info@support.com">info@support.com</a>
                             </div>
                         </div>
                         <div class="address">
@@ -532,6 +536,8 @@
 <script src="media/jquery.magnific-popup.min.js"></script>
 
 <script src="media/wow.min.js"></script>
+
+<script src="./media/material-init.js"></script>
 
 <script src="./media/custom.js"></script>
 

--- a/blog-standard.html
+++ b/blog-standard.html
@@ -23,9 +23,13 @@
 
     <link href="./media/style.css" rel="stylesheet">
 
+    <link href="./media/material-theme.css" rel="stylesheet">
+
     <title>Creasoft - Software and Digital Agency HTML Template</title>
+    <script type="module" src="https://unpkg.com/@material/web/all.js?module"></script>
+
 </head>
-<body>
+<body class="material-theme">
 
 <div class="preloader" style="display: none;">
     <div class="loader">
@@ -383,12 +387,12 @@
                         <ul class="footer-menu">
                             <li><a href="about.html">About Us</a></li>
                             <li>
-                                <a href="services.html">Services</a>
+                                <a href="service.html">Services</a>
                             </li>
                             <li><a href="project.html">Project</a></li>
                             <li><a href="blog.html">Blog</a></li>
                             <li><a href="contact.html">Career</a></li>
-                            <li><a href="services.html">Pricing
+                            <li><a href="service.html">Pricing
                                 Plan</a></li>
                         </ul>
                     </div>
@@ -410,8 +414,8 @@
                                 <i class="far fa-envelope"></i>
                             </div>
                             <div class="email">
-                                <a href="tell:info@example.com">info@example.com</a>
-                                <a href="tell:info@support.com">info@support.com</a>
+                                <a href="tel:info@example.com">info@example.com</a>
+                                <a href="tel:info@support.com">info@support.com</a>
                             </div>
                         </div>
                         <div class="address">
@@ -462,6 +466,8 @@
 <script src="media/jquery.magnific-popup.min.js"></script>
 
 <script src="media/wow.min.js"></script>
+
+<script src="./media/material-init.js"></script>
 
 <script src="./media/custom.js"></script>
 

--- a/blog.html
+++ b/blog.html
@@ -23,9 +23,13 @@
 
     <link href="./media/style.css" rel="stylesheet">
 
+    <link href="./media/material-theme.css" rel="stylesheet">
+
     <title>Creasoft - Software and Digital Agency HTML Template</title>
+    <script type="module" src="https://unpkg.com/@material/web/all.js?module"></script>
+
 </head>
-<body>
+<body class="material-theme">
 
 <div class="preloader" style="display: none;">
     <div class="loader">
@@ -505,12 +509,12 @@
                         <ul class="footer-menu">
                             <li><a href="about.html">About Us</a></li>
                             <li>
-                                <a href="services.html">Services</a>
+                                <a href="service.html">Services</a>
                             </li>
                             <li><a href="project.html">Project</a></li>
                             <li><a class="active" href="blog.html">Blog</a></li>
                             <li><a href="contact.html">Career</a></li>
-                            <li><a href="services.html">Pricing
+                            <li><a href="service.html">Pricing
                                 Plan</a></li>
                         </ul>
                     </div>
@@ -532,8 +536,8 @@
                                 <i class="far fa-envelope"></i>
                             </div>
                             <div class="email">
-                                <a href="tell:info@example.com">info@example.com</a>
-                                <a href="tell:info@support.com">info@support.com</a>
+                                <a href="tel:info@example.com">info@example.com</a>
+                                <a href="tel:info@support.com">info@support.com</a>
                             </div>
                         </div>
                         <div class="address">
@@ -584,6 +588,8 @@
 <script src="media/jquery.magnific-popup.min.js"></script>
 
 <script src="media/wow.min.js"></script>
+
+<script src="./media/material-init.js"></script>
 
 <script src="./media/custom.js"></script>
 

--- a/careers.html
+++ b/careers.html
@@ -23,9 +23,13 @@
 
     <link href="./media/style.css" rel="stylesheet">
 
+    <link href="./media/material-theme.css" rel="stylesheet">
+
     <title>Emulation AI</title>
+    <script type="module" src="https://unpkg.com/@material/web/all.js?module"></script>
+
 </head>
-<body>
+<body class="material-theme">
 
 <div class="preloader" style="display: none;">
     <div class="loader">
@@ -284,7 +288,7 @@
                                 <i class="far fa-envelope"></i>
                             </div>
                             <div class="email">
-                                <a href="mail:hello@emulationai.">hello@emulationai.com</a>
+                                <a href="mailto:hello@emulationai.com">hello@emulationai.com</a>
                             </div>
                         </div>
                     </div>
@@ -330,6 +334,8 @@
 <script src="media/jquery.magnific-popup.min.js"></script>
 
 <script src="media/wow.min.js"></script>
+
+<script src="./media/material-init.js"></script>
 
 <script src="./media/custom.js"></script>
 

--- a/contact.html
+++ b/contact.html
@@ -23,9 +23,13 @@
 
     <link href="./media/style.css" rel="stylesheet">
 
+    <link href="./media/material-theme.css" rel="stylesheet">
+
     <title>Creasoft - Software and Digital Agency HTML Template</title>
+    <script type="module" src="https://unpkg.com/@material/web/all.js?module"></script>
+
 </head>
-<body>
+<body class="material-theme">
 
 <div class="preloader" style="display: none;">
     <div class="loader">
@@ -201,8 +205,8 @@
                                 </div>
                                 <div class="info">
                                     <h3>Email</h3>
-                                    <a href="tell:info@example.com">info@example.com</a>
-                                    <a href="tell:info@support.com">info@support.com</a>
+                                    <a href="tel:info@example.com">info@example.com</a>
+                                    <a href="tel:info@support.com">info@support.com</a>
                                 </div>
                             </div>
                         </div>
@@ -324,12 +328,12 @@
                         <ul class="footer-menu">
                             <li><a href="about.html">About Us</a></li>
                             <li>
-                                <a href="services.html">Services</a>
+                                <a href="service.html">Services</a>
                             </li>
                             <li><a href="project.html">Project</a></li>
                             <li><a href="blog.html">Blog</a></li>
                             <li><a class="active" href="contact.html">Career</a></li>
-                            <li><a href="services.html">Pricing
+                            <li><a href="service.html">Pricing
                                 Plan</a></li>
                         </ul>
                     </div>
@@ -351,8 +355,8 @@
                                 <i class="far fa-envelope"></i>
                             </div>
                             <div class="email">
-                                <a href="tell:info@example.com">info@example.com</a>
-                                <a href="tell:info@support.com">info@support.com</a>
+                                <a href="tel:info@example.com">info@example.com</a>
+                                <a href="tel:info@support.com">info@support.com</a>
                             </div>
                         </div>
                         <div class="address">
@@ -403,6 +407,8 @@
 <script src="media/jquery.magnific-popup.min.js"></script>
 
 <script src="media/wow.min.js"></script>
+
+<script src="./media/material-init.js"></script>
 
 <script src="./media/custom.js"></script>
 

--- a/error.html
+++ b/error.html
@@ -23,9 +23,13 @@
 
     <link href="./media/style.css" rel="stylesheet">
 
+    <link href="./media/material-theme.css" rel="stylesheet">
+
     <title>Creasoft - Software and Digital Agency HTML Template</title>
+    <script type="module" src="https://unpkg.com/@material/web/all.js?module"></script>
+
 </head>
-<body>
+<body class="material-theme">
 
 <div class="preloader" style="display: none;">
     <div class="loader">
@@ -219,12 +223,12 @@
                         <ul class="footer-menu">
                             <li><a href="about.html">About Us</a></li>
                             <li>
-                                <a href="services.html">Services</a>
+                                <a href="service.html">Services</a>
                             </li>
                             <li><a href="project.html">Project</a></li>
                             <li><a href="blog.html">Blog</a></li>
                             <li><a href="contact.html">Career</a></li>
-                            <li><a href="services.html">Pricing
+                            <li><a href="service.html">Pricing
                                 Plan</a></li>
                         </ul>
                     </div>
@@ -246,8 +250,8 @@
                                 <i class="far fa-envelope"></i>
                             </div>
                             <div class="email">
-                                <a href="tell:info@example.com">info@example.com</a>
-                                <a href="tell:info@support.com">info@support.com</a>
+                                <a href="tel:info@example.com">info@example.com</a>
+                                <a href="tel:info@support.com">info@support.com</a>
                             </div>
                         </div>
                         <div class="address">
@@ -298,6 +302,8 @@
 <script src="media/jquery.magnific-popup.min.js"></script>
 
 <script src="media/wow.min.js"></script>
+
+<script src="./media/material-init.js"></script>
 
 <script src="./media/custom.js"></script>
 

--- a/faq.html
+++ b/faq.html
@@ -23,9 +23,13 @@
 
     <link href="./media/style.css" rel="stylesheet">
 
+    <link href="./media/material-theme.css" rel="stylesheet">
+
     <title>Creasoft - Software and Digital Agency HTML Template</title>
+    <script type="module" src="https://unpkg.com/@material/web/all.js?module"></script>
+
 </head>
-<body>
+<body class="material-theme">
 
 <div class="preloader" style="display: none;">
     <div class="loader">
@@ -601,12 +605,12 @@
                         <ul class="footer-menu">
                             <li><a href="about.html">About Us</a></li>
                             <li>
-                                <a href="services.html">Services</a>
+                                <a href="service.html">Services</a>
                             </li>
                             <li><a href="project.html">Project</a></li>
                             <li><a href="blog.html">Blog</a></li>
                             <li><a href="contact.html">Career</a></li>
-                            <li><a href="services.html">Pricing
+                            <li><a href="service.html">Pricing
                                 Plan</a></li>
                         </ul>
                     </div>
@@ -628,8 +632,8 @@
                                 <i class="far fa-envelope"></i>
                             </div>
                             <div class="email">
-                                <a href="tell:info@example.com">info@example.com</a>
-                                <a href="tell:info@support.com">info@support.com</a>
+                                <a href="tel:info@example.com">info@example.com</a>
+                                <a href="tel:info@support.com">info@support.com</a>
                             </div>
                         </div>
                         <div class="address">
@@ -680,6 +684,8 @@
 <script src="media/jquery.magnific-popup.min.js"></script>
 
 <script src="media/wow.min.js"></script>
+
+<script src="./media/material-init.js"></script>
 
 <script src="./media/custom.js"></script>
 

--- a/home2.html
+++ b/home2.html
@@ -23,9 +23,13 @@
 
     <link href="./media/style.css" rel="stylesheet">
 
+    <link href="./media/material-theme.css" rel="stylesheet">
+
     <title>Creasoft - Software and Digital Agency HTML Template</title>
+    <script type="module" src="https://unpkg.com/@material/web/all.js?module"></script>
+
 </head>
-<body>
+<body class="material-theme">
 
 <div class="preloader" style="display: none;">
     <div class="loader">
@@ -1470,12 +1474,12 @@
                             <h4>Quick Links</h4>
                             <ul class="footer-menu">
                                 <li><a href="about.html">About Us</a></li>
-                                <li><a href="services.html">Services</a>
+                                <li><a href="service.html">Services</a>
                                 </li>
                                 <li><a href="project.html">Project</a></li>
                                 <li><a href="blog.html">Blog</a></li>
                                 <li><a href="contact.html">Career</a></li>
-                                <li><a href="services.html">Pricing
+                                <li><a href="service.html">Pricing
                                     Plan</a></li>
                             </ul>
                         </div>
@@ -1497,8 +1501,8 @@
                                     <i class="far fa-envelope"></i>
                                 </div>
                                 <div class="email">
-                                    <a href="tell:info@example.com">info@example.com</a>
-                                    <a href="tell:info@support.com">info@support.com</a>
+                                    <a href="tel:info@example.com">info@example.com</a>
+                                    <a href="tel:info@support.com">info@support.com</a>
                                 </div>
                             </div>
                             <div class="address">
@@ -1555,6 +1559,8 @@
 
 <script src="./media/particles.min.js.download"></script>
 <script src="./media/app.js"></script>
+
+<script src="./media/material-init.js"></script>
 
 <script src="./media/custom.js"></script>
 

--- a/index.html
+++ b/index.html
@@ -23,9 +23,13 @@
 
     <link href="./media/style.css" rel="stylesheet">
 
+    <link href="./media/material-theme.css" rel="stylesheet">
+
     <title>Emulation AI</title>
+    <script type="module" src="https://unpkg.com/@material/web/all.js?module"></script>
+
 </head>
-<body>
+<body class="material-theme">
 
 <div class="preloader" style="display: none;">
     <div class="loader">
@@ -428,7 +432,7 @@
                                     <i class="far fa-envelope"></i>
                                 </div>
                                 <div class="email">
-                                    <a href="mail:hello@emulationai.">hello@emulationai.com</a>
+                                    <a href="mailto:hello@emulationai.com">hello@emulationai.com</a>
                                 </div>
                             </div>
                         </div>
@@ -477,6 +481,8 @@
 <script src="media/jquery.magnific-popup.min.js"></script>
 
 <script src="media/wow.min.js"></script>
+
+<script src="./media/material-init.js"></script>
 
 <script src="./media/custom.js"></script>
 

--- a/media/material-init.js
+++ b/media/material-init.js
@@ -1,0 +1,23 @@
+document.addEventListener("DOMContentLoaded", () => {
+    document.body.classList.add("material-theme");
+
+    document.querySelectorAll(".cmn-btn a, .submit-btn, button").forEach((el) => {
+        el.classList.add("mat-pill-action");
+        if (!el.querySelector("md-ripple")) {
+            const ripple = document.createElement("md-ripple");
+            ripple.setAttribute("for", "");
+            el.appendChild(ripple);
+        }
+    });
+
+    const currentPath = (location.pathname.split("/").pop() || "index.html").toLowerCase();
+    document.querySelectorAll(".main-nav a[href]").forEach((a) => {
+        const href = (a.getAttribute("href") || "").toLowerCase();
+        if (!href || href.startsWith("#")) {
+            return;
+        }
+        if (href === currentPath || (currentPath === "" && href === "index.html")) {
+            a.classList.add("active");
+        }
+    });
+});

--- a/media/material-theme.css
+++ b/media/material-theme.css
@@ -1,0 +1,141 @@
+:root {
+    --md-sys-color-primary: #2f6fdd;
+    --md-sys-color-on-primary: #fff;
+    --md-sys-color-secondary: #006c4e;
+    --md-sys-color-surface: #f8f9fd;
+    --md-sys-color-on-surface: #1b1c20;
+    --md-sys-color-outline-variant: #dfe2ea;
+    --mat-shadow-1: 0 1px 2px rgba(17, 24, 39, 0.08), 0 1px 3px rgba(17, 24, 39, 0.06);
+    --mat-shadow-2: 0 6px 20px rgba(17, 24, 39, 0.12);
+}
+
+body.material-theme {
+    background: var(--md-sys-color-surface);
+    color: var(--md-sys-color-on-surface);
+    font-family: "Roboto", "Saira", sans-serif;
+}
+
+body.material-theme h1,
+body.material-theme h2,
+body.material-theme h3,
+body.material-theme h4,
+body.material-theme h5,
+body.material-theme h6 {
+    font-family: "Roboto", "Saira", sans-serif;
+    letter-spacing: 0.01em;
+}
+
+body.material-theme .header-area {
+    background: rgba(255, 255, 255, 0.86);
+    backdrop-filter: blur(10px);
+    box-shadow: var(--mat-shadow-1);
+}
+
+body.material-theme .main-nav ul li a {
+    border-radius: 999px;
+    color: #3e4557;
+    font-weight: 500;
+    padding: 8px 14px;
+    transition: all 0.2s ease;
+}
+
+body.material-theme .main-nav ul li a:hover,
+body.material-theme .main-nav ul li a.active {
+    background: rgba(47, 111, 221, 0.12);
+    color: var(--md-sys-color-primary);
+}
+
+body.material-theme .hero-area,
+body.material-theme .breadcrumb-area {
+    border-radius: 0 0 28px 28px;
+    overflow: hidden;
+}
+
+body.material-theme .single-service,
+body.material-theme .single-blog,
+body.material-theme .single-team,
+body.material-theme .single-pricing,
+body.material-theme .single-project,
+body.material-theme .widget,
+body.material-theme .contact-wrapper,
+body.material-theme .faq-wrap .accordion-item {
+    background: #fff;
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: 20px;
+    box-shadow: var(--mat-shadow-1);
+}
+
+body.material-theme .single-service:hover,
+body.material-theme .single-blog:hover,
+body.material-theme .single-team:hover,
+body.material-theme .single-pricing:hover,
+body.material-theme .single-project:hover {
+    box-shadow: var(--mat-shadow-2);
+    transform: translateY(-2px);
+}
+
+body.material-theme .cmn-btn a,
+body.material-theme button,
+body.material-theme .submit-btn {
+    align-items: center;
+    background: var(--md-sys-color-primary);
+    border: 0;
+    border-radius: 999px;
+    color: var(--md-sys-color-on-primary);
+    display: inline-flex;
+    font-weight: 600;
+    gap: 8px;
+    letter-spacing: 0.01em;
+    min-height: 42px;
+    padding: 0 20px;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+body.material-theme .mat-pill-action {
+    overflow: hidden;
+    position: relative;
+}
+
+body.material-theme .cmn-btn.layout-two a {
+    background: var(--md-sys-color-secondary);
+}
+
+body.material-theme .cmn-btn a:hover,
+body.material-theme button:hover,
+body.material-theme .submit-btn:hover {
+    box-shadow: var(--mat-shadow-2);
+    transform: translateY(-1px);
+}
+
+body.material-theme input,
+body.material-theme textarea,
+body.material-theme select {
+    background: #fff;
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: 12px;
+    min-height: 46px;
+    padding: 0 14px;
+}
+
+body.material-theme textarea {
+    min-height: 120px;
+    padding: 12px 14px;
+}
+
+body.material-theme input:focus,
+body.material-theme textarea:focus,
+body.material-theme select:focus {
+    border-color: var(--md-sys-color-primary);
+    box-shadow: 0 0 0 3px rgba(47, 111, 221, 0.18);
+}
+
+body.material-theme .footer-area {
+    background: #10141f;
+    border-radius: 28px 28px 0 0;
+    margin-top: 48px;
+}
+
+body.material-theme .sec-title span {
+    color: var(--md-sys-color-primary);
+    font-weight: 600;
+}

--- a/news.html
+++ b/news.html
@@ -23,9 +23,13 @@
 
     <link href="./media/style.css" rel="stylesheet">
 
+    <link href="./media/material-theme.css" rel="stylesheet">
+
     <title>Emulation AI</title>
+    <script type="module" src="https://unpkg.com/@material/web/all.js?module"></script>
+
 </head>
-<body>
+<body class="material-theme">
 
 <div class="preloader" style="display: none;">
     <div class="loader">
@@ -371,7 +375,7 @@
                                 <i class="far fa-envelope"></i>
                             </div>
                             <div class="email">
-                                <a href="mail:hello@emulationai.">hello@emulationai.com</a>
+                                <a href="mailto:hello@emulationai.com">hello@emulationai.com</a>
                             </div>
                         </div>
                     </div>
@@ -417,6 +421,8 @@
 <script src="media/jquery.magnific-popup.min.js"></script>
 
 <script src="media/wow.min.js"></script>
+
+<script src="./media/material-init.js"></script>
 
 <script src="./media/custom.js"></script>
 

--- a/pricing.html
+++ b/pricing.html
@@ -23,9 +23,13 @@
 
     <link href="./media/style.css" rel="stylesheet">
 
+    <link href="./media/material-theme.css" rel="stylesheet">
+
     <title>Creasoft - Software and Digital Agency HTML Template</title>
+    <script type="module" src="https://unpkg.com/@material/web/all.js?module"></script>
+
 </head>
-<body>
+<body class="material-theme">
 
 <div class="preloader" style="display: none;">
     <div class="loader">
@@ -399,12 +403,12 @@
                         <ul class="footer-menu">
                             <li><a href="about.html">About Us</a></li>
                             <li>
-                                <a href="services.html">Services</a>
+                                <a href="service.html">Services</a>
                             </li>
                             <li><a href="project.html">Project</a></li>
                             <li><a href="blog.html">Blog</a></li>
                             <li><a href="contact.html">Career</a></li>
-                            <li><a href="services.html">Pricing
+                            <li><a href="service.html">Pricing
                                 Plan</a></li>
                         </ul>
                     </div>
@@ -426,8 +430,8 @@
                                 <i class="far fa-envelope"></i>
                             </div>
                             <div class="email">
-                                <a href="tell:info@example.com">info@example.com</a>
-                                <a href="tell:info@support.com">info@support.com</a>
+                                <a href="tel:info@example.com">info@example.com</a>
+                                <a href="tel:info@support.com">info@support.com</a>
                             </div>
                         </div>
                         <div class="address">
@@ -478,6 +482,8 @@
 <script src="media/jquery.magnific-popup.min.js"></script>
 
 <script src="media/wow.min.js"></script>
+
+<script src="./media/material-init.js"></script>
 
 <script src="./media/custom.js"></script>
 

--- a/project-details.html
+++ b/project-details.html
@@ -23,9 +23,13 @@
 
     <link href="./media/style.css" rel="stylesheet">
 
+    <link href="./media/material-theme.css" rel="stylesheet">
+
     <title>Creasoft - Software and Digital Agency HTML Template</title>
+    <script type="module" src="https://unpkg.com/@material/web/all.js?module"></script>
+
 </head>
-<body>
+<body class="material-theme">
 
 <div class="preloader" style="display: none;">
     <div class="loader">
@@ -346,8 +350,8 @@
                                 </div>
                                 <div class="cnt">
                                     <h5>Email</h5>
-                                    <a href="tell:info@example.com">info@example.com</a>
-                                    <a href="tell:info@support.com">info@support.com</a>
+                                    <a href="tel:info@example.com">info@example.com</a>
+                                    <a href="tel:info@support.com">info@support.com</a>
                                 </div>
                             </div>
                         </div>
@@ -588,12 +592,12 @@
                         <ul class="footer-menu">
                             <li><a href="about.html">About Us</a></li>
                             <li>
-                                <a href="services.html">Services</a>
+                                <a href="service.html">Services</a>
                             </li>
                             <li><a href="project.html">Project</a></li>
                             <li><a href="blog.html">Blog</a></li>
                             <li><a href="contact.html">Career</a></li>
-                            <li><a href="services.html">Pricing
+                            <li><a href="service.html">Pricing
                                 Plan</a></li>
                         </ul>
                     </div>
@@ -615,8 +619,8 @@
                                 <i class="far fa-envelope"></i>
                             </div>
                             <div class="email">
-                                <a href="tell:info@example.com">info@example.com</a>
-                                <a href="tell:info@support.com">info@support.com</a>
+                                <a href="tel:info@example.com">info@example.com</a>
+                                <a href="tel:info@support.com">info@support.com</a>
                             </div>
                         </div>
                         <div class="address">
@@ -668,6 +672,8 @@
 <script src="media/jquery.magnific-popup.min.js"></script>
 
 <script src="media/wow.min.js"></script>
+
+<script src="./media/material-init.js"></script>
 
 <script src="./media/custom.js"></script>
 

--- a/project.html
+++ b/project.html
@@ -23,9 +23,13 @@
 
     <link href="./media/style.css" rel="stylesheet">
 
+    <link href="./media/material-theme.css" rel="stylesheet">
+
     <title>Creasoft - Software and Digital Agency HTML Template</title>
+    <script type="module" src="https://unpkg.com/@material/web/all.js?module"></script>
+
 </head>
-<body>
+<body class="material-theme">
 
 <div class="preloader" style="display: none;">
     <div class="loader">
@@ -398,12 +402,12 @@
                         <ul class="footer-menu">
                             <li><a href="about.html">About Us</a></li>
                             <li>
-                                <a href="services.html">Services</a>
+                                <a href="service.html">Services</a>
                             </li>
                             <li><a class="active" href="project.html">Project</a></li>
                             <li><a href="blog.html">Blog</a></li>
                             <li><a href="contact.html">Career</a></li>
-                            <li><a href="services.html">Pricing
+                            <li><a href="service.html">Pricing
                                 Plan</a></li>
                         </ul>
                     </div>
@@ -425,8 +429,8 @@
                                 <i class="far fa-envelope"></i>
                             </div>
                             <div class="email">
-                                <a href="tell:info@example.com">info@example.com</a>
-                                <a href="tell:info@support.com">info@support.com</a>
+                                <a href="tel:info@example.com">info@example.com</a>
+                                <a href="tel:info@support.com">info@support.com</a>
                             </div>
                         </div>
                         <div class="address">
@@ -477,6 +481,8 @@
 <script src="media/jquery.magnific-popup.min.js"></script>
 
 <script src="media/wow.min.js"></script>
+
+<script src="./media/material-init.js"></script>
 
 <script src="./media/custom.js"></script>
 

--- a/service-details.html
+++ b/service-details.html
@@ -23,9 +23,13 @@
 
     <link href="./media/style.css" rel="stylesheet">
 
+    <link href="./media/material-theme.css" rel="stylesheet">
+
     <title>Creasoft - Software and Digital Agency HTML Template</title>
+    <script type="module" src="https://unpkg.com/@material/web/all.js?module"></script>
+
 </head>
-<body>
+<body class="material-theme">
 
 <div class="preloader" style="display: none;">
     <div class="loader">
@@ -344,12 +348,12 @@
                         <ul class="footer-menu">
                             <li><a href="about.html">About Us</a></li>
                             <li>
-                                <a href="services.html">Services</a>
+                                <a href="service.html">Services</a>
                             </li>
                             <li><a href="project.html">Project</a></li>
                             <li><a href="blog.html">Blog</a></li>
                             <li><a href="contact.html">Career</a></li>
-                            <li><a href="services.html">Pricing
+                            <li><a href="service.html">Pricing
                                 Plan</a></li>
                         </ul>
                     </div>
@@ -371,8 +375,8 @@
                                 <i class="far fa-envelope"></i>
                             </div>
                             <div class="email">
-                                <a href="tell:info@example.com">info@example.com</a>
-                                <a href="tell:info@support.com">info@support.com</a>
+                                <a href="tel:info@example.com">info@example.com</a>
+                                <a href="tel:info@support.com">info@support.com</a>
                             </div>
                         </div>
                         <div class="address">
@@ -424,6 +428,8 @@
 <script src="media/jquery.magnific-popup.min.js"></script>
 
 <script src="media/wow.min.js"></script>
+
+<script src="./media/material-init.js"></script>
 
 <script src="./media/custom.js"></script>
 

--- a/service.html
+++ b/service.html
@@ -23,9 +23,13 @@
 
     <link href="./media/style.css" rel="stylesheet">
 
+    <link href="./media/material-theme.css" rel="stylesheet">
+
     <title>Creasoft - Software and Digital Agency HTML Template</title>
+    <script type="module" src="https://unpkg.com/@material/web/all.js?module"></script>
+
 </head>
-<body>
+<body class="material-theme">
 
 <div class="preloader" style="display: none;">
     <div class="loader">
@@ -713,12 +717,12 @@
                         <ul class="footer-menu">
                             <li><a href="about.html">About Us</a></li>
                             <li>
-                                <a href="services.html">Services</a>
+                                <a href="service.html">Services</a>
                             </li>
                             <li><a href="project.html">Project</a></li>
                             <li><a href="blog.html">Blog</a></li>
                             <li><a href="contact.html">Career</a></li>
-                            <li><a href="services.html">Pricing
+                            <li><a href="service.html">Pricing
                                 Plan</a></li>
                         </ul>
                     </div>
@@ -740,8 +744,8 @@
                                 <i class="far fa-envelope"></i>
                             </div>
                             <div class="email">
-                                <a href="tell:info@example.com">info@example.com</a>
-                                <a href="tell:info@support.com">info@support.com</a>
+                                <a href="tel:info@example.com">info@example.com</a>
+                                <a href="tel:info@support.com">info@support.com</a>
                             </div>
                         </div>
                         <div class="address">
@@ -792,6 +796,8 @@
 <script src="media/jquery.magnific-popup.min.js"></script>
 
 <script src="media/wow.min.js"></script>
+
+<script src="./media/material-init.js"></script>
 
 <script src="./media/custom.js"></script>
 

--- a/team.html
+++ b/team.html
@@ -23,9 +23,13 @@
 
     <link href="./media/style.css" rel="stylesheet">
 
+    <link href="./media/material-theme.css" rel="stylesheet">
+
     <title>Creasoft - Software and Digital Agency HTML Template</title>
+    <script type="module" src="https://unpkg.com/@material/web/all.js?module"></script>
+
 </head>
-<body>
+<body class="material-theme">
 
 <div class="preloader" style="display: none;">
     <div class="loader">
@@ -483,12 +487,12 @@
                         <ul class="footer-menu">
                             <li><a href="about.html">About Us</a></li>
                             <li>
-                                <a href="services.html">Services</a>
+                                <a href="service.html">Services</a>
                             </li>
                             <li><a href="project.html">Project</a></li>
                             <li><a href="blog.html">Blog</a></li>
                             <li><a href="contact.html">Career</a></li>
-                            <li><a href="services.html">Pricing
+                            <li><a href="service.html">Pricing
                                 Plan</a></li>
                         </ul>
                     </div>
@@ -510,8 +514,8 @@
                                 <i class="far fa-envelope"></i>
                             </div>
                             <div class="email">
-                                <a href="tell:info@example.com">info@example.com</a>
-                                <a href="tell:info@support.com">info@support.com</a>
+                                <a href="tel:info@example.com">info@example.com</a>
+                                <a href="tel:info@support.com">info@support.com</a>
                             </div>
                         </div>
                         <div class="address">
@@ -562,6 +566,8 @@
 <script src="media/jquery.magnific-popup.min.js"></script>
 
 <script src="media/wow.min.js"></script>
+
+<script src="./media/material-init.js"></script>
 
 <script src="./media/custom.js"></script>
 


### PR DESCRIPTION
## Summary
- integrate Material Web (M3) framework across all HTML pages
- add custom Material-themed CSS classes and JS behavior layer
- fix broken internal/contact links for static deployment reliability

## Notes
- all pages now load Material Web module plus media/material-theme.css and media/material-init.js
- changes are static-site compatible for GitHub Pages deployment